### PR TITLE
Populate company-name when loading a person XML object.

### DIFF
--- a/lib/HighriseAPI.class.php
+++ b/lib/HighriseAPI.class.php
@@ -1900,6 +1900,7 @@
 			$this->setCreatedAt($xml_obj->{'created-at'});
 			$this->setUpdatedAt($xml_obj->{'updated-at'});
 			$this->setCompanyId($xml_obj->{'company-id'});
+			$this->setCompanyName($xml_obj->{'company-name'});
 			
 			$this->loadContactDataFromXMLObject($xml_obj->{'contact-data'});
 			$this->loadTagsFromXMLObject($xml_obj->{'tags'});	


### PR DESCRIPTION
Attempt to populate the company-name field/member of a HighrisePerson when parsing results from Highrise. This is an optional field and no harm will come if this data is not set in the XML response.
