### PR TITLE
Don't use addNote() when calling HighrisePerson::getNotes()

### DIFF
--- a/lib/HighriseAPI.class.php
+++ b/lib/HighriseAPI.class.php
@@ -1733,7 +1733,9 @@
 				{
 					$note = new HighriseNote($this->highrise);
 					$note->loadFromXMLObject($xml_note);
-					$this->addNote($note);		
+					$note->setSubjectId($this->id);
+					$note->setSubjectType("Party");
+					$this->notes[$note->id] = $note;
 				}
 			}
 			


### PR DESCRIPTION
Calling HighrisePerson->addNote() causes the note to be saved back to Highrise. This is:
1) just plain wrong, and
2) erroneously throws an access exception when you're trying to (erroneously) update someone else's note.
