### PR TITLE
Update README.markdown

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -28,7 +28,7 @@ Create a new person and set his address
 	$person->addEmailAddress("johndoe@gmail.com");
 	
 	$address = new HighriseAddress();
-	$address->setAddress("165 Test St.");
+	$address->setStreet("165 Test St.");
 	$address->setCity("Glasgow");
 	$address->setCountry("Scotland");
 	$address->setZip("GL1");


### PR DESCRIPTION
The setAddress() method doesn't exist in HighriseAddress class. Hence, calling it triggers some errors and blocks the execution.
