### PR TITLE
Removed misplaced semicolons

### DIFF
--- a/lib/HighriseAPI.class.php
+++ b/lib/HighriseAPI.class.php
@@ -1694,7 +1694,7 @@
 			$xml = $this->getURL("/people/" . $this->id . "/emails.xml");
 			$xml_obj = simplexml_load_string($xml);
 
-			if ($this->debug == true);
+			if ($this->debug == true)
 				print_r($xml_obj);
 			
 			if (isset($xml_obj->email) && count($xml_obj->email) > 0)
@@ -1724,7 +1724,7 @@
 			$xml = $this->getURL("/people/" . $this->id . "/notes.xml");
 			$xml_obj = simplexml_load_string($xml);
 
-			if ($this->debug == true);
+			if ($this->debug == true)
 				print_r($xml_obj);
 			
 			if (isset($xml_obj->note) && count($xml_obj->note) > 0)


### PR DESCRIPTION
Removed misplaced semicolons that were causing debug messages—regardless of what `debug` was set to—for `getEmails()` and `getNotes()`
